### PR TITLE
Add clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,36 @@
+Language: Cpp
+BasedOnStyle: Google
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: None
+AlignOperands: Align
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortLambdasOnASingleLine: Inline
+AllowShortLoopsOnASingleLine: false
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterStruct: true
+  AfterControlStatement: Always
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterUnion: true
+  AfterExternBlock: true
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeLambdaBody: true
+  IndentBraces: true
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+ColumnLimit: 80
+IndentWidth: 4
+Standard: c++11
+TabWidth: 4
+UseTab: Never


### PR DESCRIPTION
Add clang-format file and git pre-commit script to format files automatically if it's installed.

If you add this to `./git/hooks/pre-commit` you will run clang-format on all changes to `cpp/`:

```
if command -v clang-format &> /dev/null; then
    echo "Auto-formatting files..."
    find cpp                                                                    \
        -type f                                                                 \
        -not -path "cpp/build/*"                                                \
        -not -path "cpp/third_party/*"                                          \
        -not -path "cpp/.cache/*"                                               \
        \( -name "*.h" -or -name "*.cpp" \)                                     \
        -exec echo "Running clang-format on: {}" \;                             \
        -exec clang-format -i {} \;
else
    echo "clang-format not installed, skipping precommit hook. Please put it on your system path if you want auto-formatting!"
fi
```